### PR TITLE
Updated YouTube embed code

### DIFF
--- a/ee1/pi.antenna.php
+++ b/ee1/pi.antenna.php
@@ -86,7 +86,7 @@ class Antenna {
 
 		// If it's not YouTube or Vimeo, bail
 		if (strpos($video_url, "youtube.com/") !== FALSE) {
-			$url = "http://www.youtube.com/oembed?format=json&url=";
+			$url = "http://www.youtube.com/oembed?format=json&iframe=1&url=";
 		} else if (strpos($video_url, "vimeo.com/") !== FALSE) {
 			$url = "http://vimeo.com/api/oembed.json?url=";
 		} else if (strpos($video_url, "wistia.com/") !== FALSE) {

--- a/ee2/antenna/pi.antenna.php
+++ b/ee2/antenna/pi.antenna.php
@@ -73,7 +73,7 @@ class Antenna
 
 		// If it's not YouTube or Vimeo, bail
 		if (strpos($video_url, "youtube.com/") !== FALSE) {
-			$url = "http://www.youtube.com/oembed?format=json&url=";
+			$url = "http://www.youtube.com/oembed?format=json&iframe=1&url=";
 		} else if (strpos($video_url, "vimeo.com/") !== FALSE) {
 			$url = "http://vimeo.com/api/oembed.json?url=";
 		} else if (strpos($video_url, "wistia.com/") !== FALSE) {


### PR DESCRIPTION
Put the `&iframe=1` param in to let oEmbed know to use the new embed code. Works a charm in iOS where it didn't before.
