### PR TITLE
Update for Vimeo thumbnails

### DIFF
--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -9,7 +9,7 @@ if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
 $plugin_info = array(
 	'pi_name'			=> 'Antenna',
-	'pi_version'		=> '1.25',
+	'pi_version'		=> '1.26',
 	'pi_author'			=> 'Matt Weinberg',
 	'pi_author_url'		=> 'http://www.VectorMediaGroup.com',
 	'pi_description'	=> 'Returns the embed code and various pieces of metadata for YouTube, Vimeo, Wistia, and Viddler Videos',


### PR DESCRIPTION
Vimeo seems to have changed their oembed thumbnail_url which broke the {video_mediumres} and {video_highres} tags. It also made {video_thumbnail} dimensions 200 x 150px. This patch brings them back in line with the YouTube thumbnail sizes.

{video_thumbnail}: 295px wide
{video_mediumres}: 640px wide
{video_highres}: 1280px wide
