### PR TITLE
Added support for specifying youtube embed url parameters using youtu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Antenna will automatically enforce HTTPS if the provided video URL has a protoco
 If you're using YouTube, you get access to one more parameter:
 
 - youtube_rel='0/1' -- Show related videos at end of video. Defaults to 1.
+- youtube_params='' -- Add additional parameters to Youtube embed url (e.g. "modestbranding=1&autohide=1&showinfo=0&controls=0")
 
 If you're using Vimeo, you get access to four more parameters and one more variable:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Antenna will automatically enforce HTTPS if the provided video URL has a protoco
 If you're using YouTube, you get access to one more parameter:
 
 - youtube_rel='0/1' -- Show related videos at end of video. Defaults to 1.
+- youtube_controls='0/1' -- Display the video player controls? Defaults to 1.
+- youtube_showinfo='0/1' -- Display video title? Defaults to 1.
+- youtube_autoplay='0/1' -- Specifies whether the initial video will automatically start to play when the player loads. Defaults to 0.
 - youtube_params='' -- Add additional parameters to Youtube embed url (e.g. "modestbranding=1&autohide=1&showinfo=0&controls=0")
 
 If you're using Vimeo, you get access to four more parameters and one more variable:

--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -32,7 +32,12 @@ class Antenna
 	public $refresh_cache = 10080;			// in mintues (default is 1 week)
 	public $cache_expired = FALSE;
 
-	public function Antenna()
+    // Some optional YouTube parameters
+    private $youtube_params = array(
+        'rel', 'modestbranding', 'autoplay', 'controls', 'showinfo'
+    );
+
+    public function Antenna()
 	{
 		$this->EE =& get_instance();
 
@@ -74,8 +79,6 @@ class Antenna
 			$this->refresh_cache = $this->EE->TMPL->fetch_param('cache_minutes');
 		}
 
-		// Some optional YouTube parameters
-		$youtube_rel = $this->EE->TMPL->fetch_param('youtube_rel', null);
         $youtube_params = $this->EE->TMPL->fetch_param('youtube_params', null);
 
 		// Some optional Vimeo parameters
@@ -170,14 +173,17 @@ class Antenna
             if (!empty($matches[1])) {
                 $youtube_url_original = $youtube_url = $matches[1];
 
-                // Inject YouTube rel value if required
-                if(!is_null($youtube_rel)) {
-                    $youtube_url .= '&rel=' . $youtube_rel;
+                // $yt_param will be ie. 'modestbranding'
+                foreach($this->youtube_params as $yt_param) {
+                    $yt_value = $this->EE->TMPL->fetch_param('youtube_'.$yt_param, null);   // fetch youtube_modestbranding, etc.
+                    if(!is_null($yt_value)) {  // if set add value to url
+                        $youtube_url .= '&'.$yt_param.'='.$yt_value;   // add to url, ie. &rel=0
+                    }
                 }
 
-                // allows for adding additional youtube params eg. modestbranding=1&autohide=1&showinfo=0&controls=0
+                // allows for adding multiple youtube params at once eg. modestbranding=1&autohide=1&showinfo=0&controls=0
                 if(!is_null($youtube_params)) {
-                    $youtube_url .= $youtube_params;
+                    $youtube_url .= '&'.$youtube_params;
                 }
 
                 $video_info->html = str_replace($youtube_url_original, $youtube_url, $video_info->html);

--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -76,6 +76,7 @@ class Antenna
 
 		// Some optional YouTube parameters
 		$youtube_rel = $this->EE->TMPL->fetch_param('youtube_rel', null);
+        $youtube_params = $this->EE->TMPL->fetch_param('youtube_params', null);
 
 		// Some optional Vimeo parameters
 		$vimeo_byline	= ($this->EE->TMPL->fetch_param('vimeo_byline') == "false") ? "&byline=false" : "";
@@ -162,12 +163,26 @@ class Antenna
 	    	}
     	}
 
-    	// Inject YouTube rel value if required
-    	if (!is_null($youtube_rel) && (strpos($video_url, "youtube.com/") !== FALSE OR strpos($video_url, "youtu.be/") !== FALSE))
-		{
-			preg_match('/.*?src="(.*?)".*?/', $video_info->html, $matches);
-			if (!empty($matches[1])) $video_info->html = str_replace($matches[1], $matches[1] . '&rel=' . $youtube_rel, $video_info->html);
-		}
+        if ((strpos($video_url, "youtube.com/") !== FALSE OR strpos($video_url, "youtu.be/") !== FALSE))
+        {
+            preg_match('/.*?src="(.*?)".*?/', $video_info->html, $matches);
+
+            if (!empty($matches[1])) {
+                $youtube_url_original = $youtube_url = $matches[1];
+
+                // Inject YouTube rel value if required
+                if(!is_null($youtube_rel)) {
+                    $youtube_url .= '&rel=' . $youtube_rel;
+                }
+
+                // allows for adding additional youtube params eg. modestbranding=1&autohide=1&showinfo=0&controls=0
+                if(!is_null($youtube_params)) {
+                    $youtube_url .= $youtube_params;
+                }
+
+                $video_info->html = str_replace($youtube_url_original, $youtube_url, $video_info->html);
+            }
+        }
 
 
 	// actually setting thumbnails at a reasonably consistent size, as well as getting higher-res images


### PR DESCRIPTION
…be_params=''.


I needed to remove the title, controls etc. so I implemented support for an additional parameter in the {exp:antenna} tag - youtube_params="" ..

This will just be passed directly to the youtube url .. I use it like this:

  {exp:antenna url="_url-here_" force_https="true" youtube_params="modestbranding=1&autohide=1&showinfo=0&controls=0&rel=0"}
                    {embed_code}
{/exp:antenna}