### PR TITLE
Add support for the full list of YouTube embedded player parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Usage
 	    {if:else}
 	        No video to display here.
 	    {/if}
-
 	{/exp:antenna}
 
 
@@ -46,9 +45,12 @@ Antenna will automatically enforce HTTPS if the provided video URL has a protoco
 
 - force_https='true'
 
-If you're using YouTube, you get access to one more parameter:
+If you're using YouTube, you get access to several more parameters, such as:
 
 - youtube_rel='0/1' -- Show related videos at end of video. Defaults to 1.
+- youtube_showinfo ='0/1' -- Show the video title and uploader. Defaults to 1.
+
+See https://developers.google.com/youtube/player_parameters#Parameters for the full list of HTML5 parameters available for YouTube videos. Prefix each parameter with `youtube_` when adding these parameters to your Antenna template tag.
 
 If you're using Vimeo, you get access to four more parameters and one more variable:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Usage
 	    {video_mediumres}
 	    {video_highres}
 	    {video_provider}
+	    {video_width}
+	    {video_height}
 
 	    {!-- For Vimeo Only --}
 	    {video_description}

--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -75,7 +75,40 @@ class Antenna
 		}
 
 		// Some optional YouTube parameters
-		$youtube_rel = $this->EE->TMPL->fetch_param('youtube_rel', null);
+		$youtube_options = array(
+			'autohide',
+			'autoplay',
+			'cc_load_policy',
+			'color',
+			'controls',
+			'disablekb',
+			'enablejsapi',
+			'end',
+			'fs',
+			'hl',
+			'iv_load_policy',
+			'list',
+			'listType',
+			'loop',
+			'modestbranding',
+			'origin',
+			'playlist',
+			'playsinline',
+			'rel',
+			'showinfo',
+			'start',
+			'theme'
+		);
+		$youtube_params = array();
+		
+		foreach($youtube_options as $option)
+		{
+			$param = $this->EE->TMPL->fetch_param('youtube_'.$option, null);
+			if(!is_null($param))
+			{
+				$youtube_params[$option] = $param;
+			}
+		}
 
 		// Some optional Vimeo parameters
 		$vimeo_byline	= ($this->EE->TMPL->fetch_param('vimeo_byline') == "false") ? "&byline=false" : "";
@@ -163,11 +196,16 @@ class Antenna
 	    	}
     	}
 
-    	// Inject YouTube rel value if required
-    	if (!is_null($youtube_rel) && (strpos($video_url, "youtube.com/") !== FALSE OR strpos($video_url, "youtu.be/") !== FALSE))
+    	// Inject YouTube parameters if required
+    	if( !empty($youtube_params) && (strpos($video_url, "youtube.com/") !== FALSE OR strpos($video_url, "youtu.be/") !== FALSE))
 		{
+			$youtube_args = '';
+			foreach($youtube_params as $param => $value)
+			{
+				$youtube_args .= '&'.$param.'=' . $value;
+			}
 			preg_match('/.*?src="(.*?)".*?/', $video_info->html, $matches);
-			if (!empty($matches[1])) $video_info->html = str_replace($matches[1], $matches[1] . '&rel=' . $youtube_rel, $video_info->html);
+			if (!empty($matches[1])) $video_info->html = str_replace($matches[1], $matches[1] . $youtube_args, $video_info->html);
 		}
 
 

--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -50,7 +50,9 @@ class Antenna
 			"medres_url"	=>  "video_mediumres",
 			"highres_url"	=>  "video_highres",
 			"description"   =>  "video_description",
-			"provider"      =>  "video_provider"
+			"provider"      =>  "video_provider",
+			"width" 		=>	"video_width",
+			"height" 		=>	"video_height"
 		);
 
 		$video_data = array();


### PR DESCRIPTION
I was looking to just add the `showinfo` parameter, but stumbled across the [full list on the YouTube dev site](https://developers.google.com/youtube/player_parameters#Parameters). Figured it'd be good to just add support for the whole list. I've tested several and they all seem to work.