### PR TITLE
Added enablejsapi to enable YouTube video control via Iframe API

### DIFF
--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -173,7 +173,7 @@ class Antenna
 		}
 
 		// Inject YouTube enablejsapi value if required
-    	if ( !empty($enablejsapi))
+		if ( !empty($enablejsapi))
 		{
 			preg_match('/.*?src="(.*?)".*?/', $video_info->html, $matches);
 			if (!empty($matches[1])) $video_info->html = str_replace($matches[1], $matches[1] . '&enablejsapi=' . $enablejsapi, $video_info->html);

--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -65,6 +65,8 @@ class Antenna
 		$max_height = ($this->EE->TMPL->fetch_param('max_height')) ? "&maxheight=" . $this->EE->TMPL->fetch_param('max_height') : "";
 		$wmode = ($this->EE->TMPL->fetch_param('wmode')) ? $this->EE->TMPL->fetch_param('wmode') : "";
 		$wmode_param = ($this->EE->TMPL->fetch_param('wmode')) ? "&wmode=" . $this->EE->TMPL->fetch_param('wmode') : "";
+		$enablejsapi = ($this->EE->TMPL->fetch_param('enablejsapi')) ? $this->EE->TMPL->fetch_param('enablejsapi') : "";
+		$player_id = ($this->EE->TMPL->fetch_param('player_id')) ? $this->EE->TMPL->fetch_param('player_id') : "";
 
 		// Correct for a bug in YouTube response if only maxheight is set and the video is over 612px wide
 		if (empty($max_height)) $max_height = "&maxheight=" . $this->EE->TMPL->fetch_param('max_width');
@@ -159,7 +161,7 @@ class Antenna
 	    		preg_match('/<iframe.*?src="(.*?)".*?<\/iframe>/i', $video_info->html, $matches);
 	    		$append_query_marker = (strpos($matches[1], '?') !== false ? '' : '?');
 
-	    		$video_info->html = preg_replace('/<iframe(.*?)src="(.*?)"(.*?)<\/iframe>/i', '<iframe$1src="$2' . $append_query_marker . '&wmode=' . $wmode . '"$3</iframe>', $video_info->html);
+	    		$video_info->html = preg_replace('/<iframe(.*?)src="(.*?)"(.*?)<\/iframe>/i', '<iframe$1 id="' . $player_id . '" src="$2' . $append_query_marker . '&wmode=' . $wmode . '"$3</iframe>', $video_info->html);
 	    	}
     	}
 
@@ -168,6 +170,13 @@ class Antenna
 		{
 			preg_match('/.*?src="(.*?)".*?/', $video_info->html, $matches);
 			if (!empty($matches[1])) $video_info->html = str_replace($matches[1], $matches[1] . '&rel=' . $youtube_rel, $video_info->html);
+		}
+
+		// Inject YouTube enablejsapi value if required
+    	if ( !empty($enablejsapi))
+		{
+			preg_match('/.*?src="(.*?)".*?/', $video_info->html, $matches);
+			if (!empty($matches[1])) $video_info->html = str_replace($matches[1], $matches[1] . '&enablejsapi=' . $enablejsapi, $video_info->html);
 		}
 
 


### PR DESCRIPTION
Adds enablejsapi url param to enable YouTube Iframe API.

## Usage
````
{exp:antenna url="{youtube_url}" wmode="opaque" enablejsapi="1" player_id="player"}
````

`enablejsapi` = 1 enables, = 0 disables. `player_id` is required if `enablejsapi` is set to "1" in order to access the iframe via javascript

### Controlling the iframe with javascript
````javascript
// 2. This code loads the IFrame Player API code asynchronously.
var tag = document.createElement('script');

tag.src = "https://www.youtube.com/iframe_api";
var firstScriptTag = document.getElementsByTagName('script')[0];
firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);

// 3. This function creates an <iframe> (and YouTube player)
//    after the API code downloads.
var player;
function onYouTubeIframeAPIReady() {
  player = new YT.Player('player', { // 'player' must match player_id param
    events: {
      'onReady': onPlayerReady,
      'onStateChange': onPlayerStateChange
    }
  });
}

// 4. The API will call this function when the video player is ready.
function onPlayerReady(event) {
  event.target.playVideo();
}

// 5. The API calls this function when the player's state changes.
//    The function indicates that when playing a video (state=1),
//    the player should play for six seconds and then stop.
var done = false;
function onPlayerStateChange(event) {
  if (event.data == YT.PlayerState.PLAYING && !done) {
    setTimeout(stopVideo, 6000);
    done = true;
  }
}
function stopVideo() {
  player.stopVideo();
}
````

For more reference visit the [YouTube Iframe](https://developers.google.com/youtube/iframe_api_reference) API page