### PR TITLE
Add video_ratio variable, calculated from width/height

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Usage
 	    {video_mediumres}
 	    {video_highres}
 	    {video_provider}
+		{video_ratio}
 	    {video_width}
 	    {video_height}
 

--- a/third_party/antenna/pi.antenna.php
+++ b/third_party/antenna/pi.antenna.php
@@ -256,6 +256,11 @@ class Antenna
 			}
 		}
 
+		if(!empty($video_info->width) && !empty($video_info->height))
+		{
+			$video_data['video_ratio'] = floatval($video_info->width / $video_info->height);
+		}
+
 		$tagdata = $this->EE->functions->prep_conditionals($tagdata, $video_data);
 
 		foreach ($video_data as $key => $value)


### PR DESCRIPTION
I added this so that I could figure out when I'd been returned embed code for a standard definition video (e.g., old 4:3 video at 640 x 480 or similar). These don't adapt well to large-screen responsive designs where something like FitVids is automatically making all video fill its container width - adding `{video_ratio}` lets me add markup I can target and exclude, e.g.,

    {if video_ratio < 1.4}
        // This is an SD video
        <div class="sd-video">
            {embed_code}
        </div>
    {if:else}
        // This is an HD video
        <div class="hd-video">
            {embed_code}
        </div>
    {/if}